### PR TITLE
fix: 피드 목록 조회 이상 현상 수정

### DIFF
--- a/src/main/java/com/growith/tailo/feed/feed/controller/FeedPostController.java
+++ b/src/main/java/com/growith/tailo/feed/feed/controller/FeedPostController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -94,7 +95,10 @@ public class FeedPostController {
             Pageable pageable,
             @AuthenticationPrincipal Member member) {
 
-        Page<FeedPostResponse> feedPostList = feedPostService.getFeedPostList(member, pageable);
+        // 정렬은 무조건 update 내림차순으로 하게끔 함
+        Pageable noSortPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+
+        Page<FeedPostResponse> feedPostList = feedPostService.getFeedPostList(member, noSortPageable);
 
         FeedPostListResponse response = new FeedPostListResponse(feedPostList.getContent(), new Pagination(
                 feedPostList.getNumber(),

--- a/src/main/java/com/growith/tailo/feed/feed/dto/response/FeedPostResponse.java
+++ b/src/main/java/com/growith/tailo/feed/feed/dto/response/FeedPostResponse.java
@@ -1,19 +1,47 @@
 package com.growith.tailo.feed.feed.dto.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
-public record FeedPostResponse(
-        Long feedId,
-        String content,
-        String accountId,
-        String authorNickname,
-        String authorProfile,
-        List<String> imageUrls,
-        List<String> hashtags,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt,
-        long likesCount,
-        long commentsCount
-) {
+@Getter
+@AllArgsConstructor
+public class FeedPostResponse {
+
+    private final Long feedId;
+    private final String content;
+    private final String accountId;
+    String authorNickname;
+    String authorProfile;
+    List<String> imageUrls;
+    List<String> hashtags;
+    LocalDateTime createdAt;
+    LocalDateTime updatedAt;
+    long likesCount;
+    long commentsCount;
+
+    public FeedPostResponse(Long feedId,
+                            String content,
+                            String accountId,
+                            String authorNickname,
+                            String authorProfile,
+                            LocalDateTime createdAt,
+                            LocalDateTime updatedAt,
+                            long likesCount,
+                            long commentsCount) {
+        this.feedId = feedId;
+        this.content = content;
+        this.accountId = accountId;
+        this.authorNickname = authorNickname;
+        this.authorProfile = authorProfile;
+        this.imageUrls = new ArrayList<>();
+        this.hashtags = new ArrayList<>();
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.likesCount = likesCount;
+        this.commentsCount = commentsCount;
+    }
 }

--- a/src/main/java/com/growith/tailo/feed/feed/repository/FeedPostCustomRepositoryImpl.java
+++ b/src/main/java/com/growith/tailo/feed/feed/repository/FeedPostCustomRepositoryImpl.java
@@ -80,6 +80,9 @@ public class FeedPostCustomRepositoryImpl implements FeedPostCustomRepository {
         Long total = jpaQueryFactory
                 .select(feedPost.count())
                 .from(feedPost)
+                .leftJoin(feedImage).on(feedImage.feedPost.eq(feedPost))
+                .leftJoin(feedPostHashtag).on(feedPostHashtag.feedPost.eq(feedPost))
+                .leftJoin(hashtags).on(hashtags.id.eq(feedPostHashtag.hashtags.id))
                 .leftJoin(follow).on(follow.follower.id.eq(member.getId()))
                 .where(
                         feedPost.author.id.eq(member.getId())

--- a/src/main/java/com/growith/tailo/feed/feed/repository/FeedPostCustomRepositoryImpl.java
+++ b/src/main/java/com/growith/tailo/feed/feed/repository/FeedPostCustomRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.growith.tailo.feed.hashtag.entity.QHashtags;
 import com.growith.tailo.feed.likes.entity.QPostLike;
 import com.growith.tailo.follow.entity.QFollow;
 import com.growith.tailo.member.entity.Member;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
@@ -43,9 +44,6 @@ public class FeedPostCustomRepositoryImpl implements FeedPostCustomRepository {
 
         Map<Long, FeedPostResponse> feedMap = jpaQueryFactory
                 .from(feedPost)
-                .leftJoin(feedImage).on(feedImage.feedPost.eq(feedPost))
-                .leftJoin(feedPostHashtag).on(feedPostHashtag.feedPost.eq(feedPost))
-                .leftJoin(hashtags).on(hashtags.id.eq(feedPostHashtag.hashtags.id))
                 .leftJoin(follow).on(follow.follower.id.eq(member.getId()))
                 .where(
                         feedPost.author.id.eq(member.getId())
@@ -62,8 +60,6 @@ public class FeedPostCustomRepositoryImpl implements FeedPostCustomRepository {
                                 feedPost.author.accountId,
                                 feedPost.author.nickname,
                                 feedPost.author.profileImageUrl,
-                                GroupBy.list(feedImage.imageUrl), // 이미지들 묶기
-                                GroupBy.list(hashtags.hashtag),   // 해시태그 묶기
                                 feedPost.createdAt,
                                 feedPost.updatedAt,
                                 JPAExpressions.select(postLike.count())
@@ -77,12 +73,13 @@ public class FeedPostCustomRepositoryImpl implements FeedPostCustomRepository {
 
         List<FeedPostResponse> feeds = new ArrayList<>(feedMap.values());
 
+        insertImages(feedImage, feedMap);
+
+        insertHashTags(hashtags, feedPostHashtag, feedMap);
+
         Long total = jpaQueryFactory
                 .select(feedPost.count())
                 .from(feedPost)
-                .leftJoin(feedImage).on(feedImage.feedPost.eq(feedPost))
-                .leftJoin(feedPostHashtag).on(feedPostHashtag.feedPost.eq(feedPost))
-                .leftJoin(hashtags).on(hashtags.id.eq(feedPostHashtag.hashtags.id))
                 .leftJoin(follow).on(follow.follower.id.eq(member.getId()))
                 .where(
                         feedPost.author.id.eq(member.getId())
@@ -91,7 +88,40 @@ public class FeedPostCustomRepositoryImpl implements FeedPostCustomRepository {
                 )
                 .fetchOne();
 
+        log.info("offset: " + pageable.getOffset() + " limit: " + pageable.getPageSize() + " 피드 리스트 갯수 : " + feeds.size() + " 실제 count 갯수: " + total);
+
         return PageableExecutionUtils.getPage(feeds, pageable, () -> total);
+    }
+
+    private void insertHashTags(QHashtags hashtags, QFeedPostHashtag feedPostHashtag, Map<Long, FeedPostResponse> feedMap) {
+        List<Tuple> hashtagResults = jpaQueryFactory
+                .select(feedPostHashtag.feedPost.id, hashtags.hashtag)
+                .from(feedPostHashtag)
+                .leftJoin(hashtags).on(hashtags.id.eq(feedPostHashtag.hashtags.id))
+                .where(feedPostHashtag.feedPost.id.in(feedMap.keySet()))
+                .fetch();
+
+        for (Tuple hashtagResult : hashtagResults) {
+            Long feedId = hashtagResult.get(feedPostHashtag.feedPost.id);
+            String hashtag = hashtagResult.get(hashtags.hashtag);
+            FeedPostResponse feedPost = feedMap.get(feedId);
+            feedPost.getHashtags().add(hashtag);
+        }
+    }
+
+    private void insertImages(QFeedPostImage feedImage, Map<Long, FeedPostResponse> feedMap) {
+        List<Tuple> imageResults = jpaQueryFactory
+                .select(feedImage.feedPost.id, feedImage.imageUrl)
+                .from(feedImage)
+                .where(feedImage.feedPost.id.in(feedMap.keySet()))
+                .fetch();
+
+        for (Tuple imageResult : imageResults) {
+            Long feedId = imageResult.get(feedImage.feedPost.id);
+            String imageUrl = imageResult.get(feedImage.imageUrl);
+            FeedPostResponse feedPost = feedMap.get(feedId);
+            feedPost.getImageUrls().add(imageUrl);
+        }
     }
 
     @Override

--- a/src/main/java/com/growith/tailo/follow/service/FollowService.java
+++ b/src/main/java/com/growith/tailo/follow/service/FollowService.java
@@ -8,8 +8,11 @@ import com.growith.tailo.follow.entity.Follow;
 import com.growith.tailo.follow.repository.FollowRepository;
 import com.growith.tailo.member.entity.Member;
 import com.growith.tailo.member.repository.MemberRepository;
+import com.growith.tailo.notification.enums.NotificationType;
+import com.growith.tailo.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -24,14 +27,18 @@ import org.springframework.web.server.ResponseStatusException;
 public class FollowService {
     private final FollowRepository followRepository;
     private final MemberRepository memberRepository;
+    private final NotificationService notificationService;
+
+    @Value("${app.base-url}")
+    private String baseUrl;
 
     @Transactional
     public String follow(Member member, String accountId){
         Member target = findTarget(accountId);
-        if(member.getAccountId().equals(accountId)){
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"본인은 팔로우할 수 없습니다.");
+        if (member.getAccountId().equals(accountId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "본인은 팔로우할 수 없습니다.");
         }
-        if(followRepository.existsByFollowerAndFollowing(member,target)){
+        if (followRepository.existsByFollowerAndFollowing(member, target)) {
             throw new ResourceAlreadyExistException("이미 팔로우 된 상태입니다.");
         }
         Follow follow = Follow.builder()
@@ -39,19 +46,30 @@ public class FollowService {
                 .following(target)
                 .build();
         followRepository.save(follow);
+
+        // TODO: MQ 도입 시 비동기로 변경 예정
+        String notificationUrl = String.format("%s/api/member/profile/%s", baseUrl, member.getAccountId());
+        notificationService.send(target, member, NotificationType.FOLLOW, notificationUrl);
+
         return "팔로우 성공";
     }
+
     @Transactional
-    public String followCancel(Member member, String accountId){
+
+    public String followCancel(Member member, String accountId) {
+  
         Member target = findTarget(accountId);
 
-        if (!followRepository.existsByFollowerAndFollowing(member,target)){
+        if (!followRepository.existsByFollowerAndFollowing(member, target)) {
             throw new ResourceAlreadyExistException("팔로우 상태가 아닙니다.");
 
         }
+
         followRepository.deleteByFollowerAndFollowing(member,target);
+
         return "팔로우 취소 성공";
     }
+
     public Page<MyFollowResponse> getFollowList(String accountId, Pageable pageable) {
         Member member = findTarget(accountId);
 
@@ -67,10 +85,11 @@ public class FollowService {
                 Page.empty(pageable) : followRepository.findAllFollowMe(member, pageable);
 
     }
+
     private Member findTarget(String accountId) {
-        log.info("팔로우 조회:{}",accountId);
+        log.info("팔로우 조회:{}", accountId);
         Member target = memberRepository.findByAccountId(accountId).orElseThrow(
-                ()-> new ResourceNotFoundException(" 사용자를 찾을 수 없습니다. ")
+                () -> new ResourceNotFoundException(" 사용자를 찾을 수 없습니다. ")
         );
         return target;
     }

--- a/src/main/java/com/growith/tailo/notification/dto/NotificationDto.java
+++ b/src/main/java/com/growith/tailo/notification/dto/NotificationDto.java
@@ -20,6 +20,7 @@ public record NotificationDto(
             case LIKE -> senderName + "님이 피드에 좋아요를 눌렀습니다.";
             case COMMENT -> senderName + "님이 댓글을 남겼습니다.";
             case DM -> senderName + "님이 메시지를 보냈습니다.";
+            case FOLLOW -> senderName + "님이 팔로우 하였습니다.";
         };
 
         return NotificationDto.builder()

--- a/src/main/java/com/growith/tailo/notification/enums/NotificationType.java
+++ b/src/main/java/com/growith/tailo/notification/enums/NotificationType.java
@@ -1,7 +1,7 @@
 package com.growith.tailo.notification.enums;
 
 public enum NotificationType {
-    LIKE("좋아요"), COMMENT("댓글"), DM("메시지");
+    LIKE("좋아요"), COMMENT("댓글"), DM("메시지"), FOLLOW("팔로우");
 
     private final String notificationType;
 


### PR DESCRIPTION
# ✨(#114 )

# ✏️내용
 - 피드 목록 조회 이상 현상 수정
   - 원인
      - 피드에 여러 이미지, 해시태그가 조회 시 leftJoin이 실행되어 같은 피드가 카디널리티 곱으로 여러개가 발생되어 전체 데이터 갯수와 수가 일치하는 않아 페이징에 문제가 있는 것으로 파악 
   - 수정사항
      - 1차 수정 dsl - transform 으로 해시태그와 이미지를 Group By로 묶었음에도 이상 현상이 반복되는 것을 확인
      - 2차 수정 해시와 이미지는 따로 분리하여 조회하도록 변경

# 🎁참고사항
  - 없음