### PR TITLE
feat: 사용자 피드 이미지 목록 조회

### DIFF
--- a/src/main/java/com/growith/tailo/feed/feedImage/controller/FeedImageController.java
+++ b/src/main/java/com/growith/tailo/feed/feedImage/controller/FeedImageController.java
@@ -9,7 +9,6 @@ import com.growith.tailo.feed.feedImage.service.FeedPostImageService;
 import com.growith.tailo.member.entity.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,7 +34,7 @@ public class FeedImageController {
             })
     @GetMapping("/api/feed/{accountId}/images")
     public ResponseEntity<ApiResponse<MemberFeedImageListResponse>> getMemberFeedImageList(
-            @PathVariable("accountId") Long accountId,
+            @PathVariable("accountId") String accountId,
             Pageable pageable,
             @AuthenticationPrincipal Member member
     ) {

--- a/src/main/java/com/growith/tailo/feed/feedImage/dto/response/MemberFeedImageResponse.java
+++ b/src/main/java/com/growith/tailo/feed/feedImage/dto/response/MemberFeedImageResponse.java
@@ -1,10 +1,25 @@
 package com.growith.tailo.feed.feedImage.dto.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
 import java.time.LocalDateTime;
 
-public record MemberFeedImageResponse(
-        Long feedId,
-        String imageUrl,
-        LocalDateTime createdAt
-) {
+@Setter
+@Getter
+@AllArgsConstructor
+public class MemberFeedImageResponse {
+    private Long feedId;
+    private String imageUrl;
+    private LocalDateTime createdAt;
+
+    @Builder
+    public MemberFeedImageResponse(Long feedId, LocalDateTime createdAt) {
+        this.feedId = feedId;
+        this.imageUrl = "";
+        this.createdAt = createdAt;
+    }
+
 }

--- a/src/main/java/com/growith/tailo/feed/feedImage/repository/FeedPostImageCustomRepository.java
+++ b/src/main/java/com/growith/tailo/feed/feedImage/repository/FeedPostImageCustomRepository.java
@@ -11,5 +11,5 @@ import java.util.List;
 public interface FeedPostImageCustomRepository {
     List<String> findImageUrlsByFeedPost(FeedPost feedPost);
 
-    Page<MemberFeedImageResponse> getMemberFeedImageList(Member loginMember, Pageable pageable, Long accountId);
+    Page<MemberFeedImageResponse> getMemberFeedImageList(Member loginMember, Pageable pageable, String accountId);
 }

--- a/src/main/java/com/growith/tailo/feed/feedImage/repository/FeedPostImageRepositoryImpl.java
+++ b/src/main/java/com/growith/tailo/feed/feedImage/repository/FeedPostImageRepositoryImpl.java
@@ -7,7 +7,7 @@ import com.growith.tailo.feed.feedImage.dto.response.MemberFeedImageResponse;
 import com.growith.tailo.feed.feedImage.entity.QFeedPostImage;
 import com.growith.tailo.member.entity.Member;
 import com.growith.tailo.member.entity.QMember;
-import com.querydsl.core.types.Projections;
+import com.querydsl.core.Tuple;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +16,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -36,7 +40,7 @@ public class FeedPostImageRepositoryImpl implements FeedPostImageCustomRepositor
     }
 
     @Override
-    public Page<MemberFeedImageResponse> getMemberFeedImageList(Member loginMember, Pageable pageable, Long accountId) {
+    public Page<MemberFeedImageResponse> getMemberFeedImageList(Member loginMember, Pageable pageable, String accountId) {
 
         QFeedPostImage feedPostImage = QFeedPostImage.feedPostImage;
         QFeedPostImage subFeedPostImage = new QFeedPostImage("subFeedPostImage");
@@ -44,23 +48,91 @@ public class FeedPostImageRepositoryImpl implements FeedPostImageCustomRepositor
         QFeedPost feedPost = QFeedPost.feedPost;
         QBlockMember blockMember = QBlockMember.blockMember;
 
-        List<MemberFeedImageResponse> content = queryFactory
-                .select(Projections.constructor(MemberFeedImageResponse.class,
-                        feedPostImage.feedPost.id,
-                        feedPostImage.imageUrl,
-                        feedPost.createdAt
-                ))
+        // feedId, CreatedAt 정보 가져오기
+        List<Tuple> feeds = fetchFeeds(loginMember, pageable, accountId, author, feedPost, blockMember);
+
+        // 맵 구성
+        Map<Long, MemberFeedImageResponse> feedMap = buildFeedMap(feedPost, feeds);
+
+        // feeds의 이미지 url 정보 가져오기
+        List<Tuple> imageUrlResults = fetchImageUrls(feedPostImage, subFeedPostImage, author, feedPost, feedMap);
+
+        for (Tuple imageUrlResult : imageUrlResults) {
+            Long feedId = imageUrlResult.get(feedPost.id);
+            String imageUrl = imageUrlResult.get(feedPostImage.imageUrl);
+
+            log.info(feedId + " " + imageUrl);
+
+            MemberFeedImageResponse memberFeedImage = feedMap.get(feedId);
+            memberFeedImage.setImageUrl(imageUrl);
+        }
+
+        List<MemberFeedImageResponse> content = new ArrayList<>(feedMap.values());
+
+        // 전체 카운트 조회
+        Long total = queryFactory
+                .select(feedPost.count())
+                .from(feedPost)
+                .join(feedPost.author, author)
+                .where(
+                        author.accountId.eq(accountId),
+                        author.id.notIn(
+                                JPAExpressions.select(blockMember.blocked.id)
+                                        .from(blockMember)
+                                        .where(blockMember.blocker.id.eq(loginMember.getId()))
+                        )
+                )
+                .fetchOne();
+
+        log.debug("특정 사용자 이미지 조회 수 : " + total + " 현재 페이지 데이터 수 :" + content.size());
+
+        return PageableExecutionUtils.getPage(content, pageable, () -> total);
+    }
+
+    private List<Tuple> fetchImageUrls(QFeedPostImage feedPostImage, QFeedPostImage subFeedPostImage, QMember author, QFeedPost feedPost, Map<Long, MemberFeedImageResponse> feedMap) {
+        return queryFactory
+                .select(feedPost.id, feedPostImage.imageUrl)
                 .from(feedPostImage)
                 .join(feedPostImage.feedPost, feedPost)
                 .join(feedPost.author, author)
                 .where(
                         feedPostImage.createdAt.eq(
                                 JPAExpressions
-                                        .select(subFeedPostImage.createdAt.max())
+                                        .select(subFeedPostImage.createdAt.max()) // 최신 이미지를 조회
                                         .from(subFeedPostImage)
                                         .where(subFeedPostImage.feedPost.eq(feedPostImage.feedPost))
                         ),
-                        author.id.eq(accountId),
+                        feedPostImage.feedPost.id.in(feedMap.keySet())
+                )
+                .fetch();
+    }
+
+    private Map<Long, MemberFeedImageResponse> buildFeedMap(QFeedPost feedPost, List<Tuple> feeds) {
+        Map<Long, MemberFeedImageResponse> feedMap = new HashMap<>();
+
+        for (Tuple feed : feeds) {
+            Long feedId = feed.get(QFeedPost.feedPost.id);
+            LocalDateTime createdAt = feed.get(feedPost.createdAt);
+
+            log.info(feedId + " " + createdAt);
+
+            feedMap.put(feedId,
+                    MemberFeedImageResponse.builder()
+                            .feedId(feedId)
+                            .createdAt(createdAt)
+                            .build());
+        }
+
+        return feedMap;
+    }
+
+    private List<Tuple> fetchFeeds(Member loginMember, Pageable pageable, String accountId, QMember author, QFeedPost feedPost, QBlockMember blockMember) {
+        return queryFactory
+                .select(feedPost.id, feedPost.createdAt)
+                .from(feedPost)
+                .join(feedPost.author, author)
+                .where(
+                        author.accountId.eq(accountId),
                         author.id.notIn(
                                 JPAExpressions.select(blockMember.blocked.id)
                                         .from(blockMember)
@@ -71,23 +143,5 @@ public class FeedPostImageRepositoryImpl implements FeedPostImageCustomRepositor
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
-
-        Long total = queryFactory
-                .select(feedPost.count())
-                .from(feedPost)
-                .join(feedPost.author, author)
-                .where(
-                        author.id.eq(accountId),
-                        author.id.notIn(
-                                JPAExpressions.select(blockMember.blocked.id)
-                                        .from(blockMember)
-                                        .where(blockMember.blocker.id.eq(loginMember.getId()))
-                        )
-                )
-                .fetchOne();
-
-        log.debug("특정 사용자 이미지 조회 - total : " + total + " comments :" + content.size());
-
-        return PageableExecutionUtils.getPage(content, pageable, () -> total);
     }
 }

--- a/src/main/java/com/growith/tailo/feed/feedImage/service/FeedPostImageService.java
+++ b/src/main/java/com/growith/tailo/feed/feedImage/service/FeedPostImageService.java
@@ -21,5 +21,5 @@ public interface FeedPostImageService {
 
     void deleteImagesByFeedPost(FeedPost feedPost);
 
-    Page<MemberFeedImageResponse> getMemberFeedImageList(Member member, Pageable pageable, Long accountId);
+    Page<MemberFeedImageResponse> getMemberFeedImageList(Member member, Pageable pageable, String accountId);
 }

--- a/src/main/java/com/growith/tailo/feed/feedImage/service/impl/FeedPostImageServiceImpl.java
+++ b/src/main/java/com/growith/tailo/feed/feedImage/service/impl/FeedPostImageServiceImpl.java
@@ -63,9 +63,9 @@ public class FeedPostImageServiceImpl implements FeedPostImageService {
 
     // 특정 사용자 피드 이미지 목록 조회
     @Override
-    public Page<MemberFeedImageResponse> getMemberFeedImageList(Member member, Pageable pageable, Long accountId) {
+    public Page<MemberFeedImageResponse> getMemberFeedImageList(Member member, Pageable pageable, String accountId) {
 
-        if (member == null || !memberRepository.existsByAccountId(member.getAccountId()) || !memberRepository.existsById(accountId)) {
+        if (!memberRepository.existsByAccountId(accountId)) {
             throw new ResourceNotFoundException("해당 회원이 존재하지 않습니다.");
         }
 


### PR DESCRIPTION
feat: 회원가입 API 구현
# ✨#118

# ✏️내용
 - 사용자 피드 이미지 목록 조회
 
# 🎁참고사항
 - 이전에는 이미지있는 피드만 조회에서 사용자의 모든 피드를 조회하도록 수정했는데 거의 기능 추가랑 다름이 없어 feat으로 처리